### PR TITLE
End date replacement, Period Difference, Date of Join & Exit Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target/
 dbt_modules/
 logs/
+macros/source_freshness.sql

--- a/models/analytics/project_department_history.sql
+++ b/models/analytics/project_department_history.sql
@@ -22,8 +22,11 @@ select
     current_proj_department as previous_project,    
     new_proj_department as current_project,
     iff(effective_date='0001-01-01',emp_join_date.date_of_joining, effective_date)   as start_date,
-    
-    COALESCE(DATEADD(day, -1, lead(effective_date) OVER (PARTITION BY employee ORDER BY start_date)),'9999-12-31') as end_date 
+    COALESCE(DATEADD(day, -1, lead(effective_date) OVER (PARTITION BY employee ORDER BY start_date)),current_date() ) as end_date, 
+    datediff(day, start_date, end_date) as no_of_days,
+    datediff(month, start_date, end_date) as no_of_months,
+    datediff(year, start_date, end_date) as no_of_years
+
 
 from 
     proj 

--- a/models/analytics/reporting_history.sql
+++ b/models/analytics/reporting_history.sql
@@ -21,9 +21,13 @@ select * from (
         a.approval_status as people_manager_change_approval_status,
         effective as valid_from, 
         coalesce(dateadd(day,-1,lead(effective) 
-        over (partition by a.employee_id order by effective)),'9999-12-31') as valid_to,
+        over (partition by a.employee_id order by effective)),current_date() ) as valid_to,
         will_be_reporting_to as people_manager_id,
-        c.first_name ||' '|| c.last_name as people_manager_name
+        c.first_name ||' '|| c.last_name as people_manager_name,
+
+        datediff(day, valid_from, valid_to) as no_of_days,
+        datediff(month, valid_from, valid_to) as no_of_months,
+        datediff(year, valid_from, valid_to) as no_of_years
         from 
             reporting_changes a
             left outer join
@@ -49,7 +53,11 @@ select * from (
         then b.date_of_joining else b.original_doj_for_transfers end as valid_from,
         dateadd(day,-1,effective) as valid_to,
         people_manager_id,
-        c.first_name ||' '|| c.last_name as people_manager_name
+        c.first_name ||' '|| c.last_name as people_manager_name,
+        datediff(day, valid_from, valid_to) as no_of_days,
+        datediff(month, valid_from, valid_to) as no_of_months,
+        datediff(year, valid_from, valid_to) as no_of_years
+        
         from
             (select 
                 employee_id as employee_zoho_id,

--- a/models/stg_zoho/TB_EMPLOYEE_FORM.sql
+++ b/models/stg_zoho/TB_EMPLOYEE_FORM.sql
@@ -18,36 +18,44 @@ select
     IFNULL(SRC:"Associate_Status"::varchar(25), NULL) as associate_status,
     SRC:"CreatedTime"::varchar(15) as created_time_int,
     IFNULL(SRC:"Current_Job_Description"::varchar(250), NULL) as current_job_description,
-    //SRC:"Date_of_End_of_Internship",
+    -- SRC:"Date_of_End_of_Internship",
     case 
         when length(SRC:"Date_of_End_of_Internship") = 0 then
-            to_date('01-Jan-0001', 'DD-Mon-YYYY')
+            NULL
+            -- to_date('01-Jan-0001', 'DD-Mon-YYYY')
         else
             to_date(SRC:"Date_of_End_of_Internship"::String , 'DD-Mon-YYYY')
     end
     as date_of_end_of_internship,
-    //SRC:"Date_of_Start_of_Internship",
+    -- SRC:"Date_of_Start_of_Internship",
     case 
         when length(SRC:"Date_of_Start_of_Internship") = 0 then
-            to_date('01-Jan-0001', 'DD-Mon-YYYY')
+            NULL
+            -- to_date('01-Jan-0001', 'DD-Mon-YYYY')
         else
             to_date(SRC:"Date_of_Start_of_Internship"::String , 'DD-Mon-YYYY')
     end
     as date_of_start_of_internship,
-    
-    //SRC:"Dateofexit",
+    IFNULL(SRC:"Employee_type"::varchar(30), NULL) as employee_type,
+    -- SRC:"Dateofexit",
     case 
-        when length(SRC:"Dateofexit") = 0 then
-            to_date('01-Jan-0001', 'DD-Mon-YYYY')
+        when employee_type = 'Intern' then
+            date_of_end_of_internship
+        when length(SRC:"Dateofexit") = 0 then 
+            NULL
+            -- to_date('01-Jan-0001', 'DD-Mon-YYYY')
         else
             to_date(SRC:"Dateofexit"::String , 'DD-Mon-YYYY')
     end
     as date_of_exit,
     
-    //SRC:"Dateofjoining",
+    -- SRC:"Dateofjoining",
     case 
+        when employee_type = 'Intern' then
+            date_of_start_of_internship
         when length(SRC:"Dateofjoining") = 0 then
-            to_date('01-Jan-0001', 'DD-Mon-YYYY')
+            NULL
+            -- to_date('01-Jan-0001', 'DD-Mon-YYYY')
         else
             to_date(SRC:"Dateofjoining"::String , 'DD-Mon-YYYY')
     end
@@ -59,7 +67,7 @@ select
     SRC:"Designation"::varchar(80) as designation,
     IFNULL(SRC:"Designation.ID"::varchar(25), NULL) as designation_id,
     IFNULL(SRC:"EmailID"::varchar(40), NULL) as email_id,
-    IFNULL(SRC:"Employee_type"::varchar(30), NULL) as employee_type,
+    
     IFNULL(SRC:"EmployeeID"::varchar(15), NULL) as employee_id,
     IFNULL(SRC:"Employeestatus"::varchar(25), NULL) as employee_status,
     IFNULL(SRC:"Exp_in_VBI_Months"::smallint, NULL) as exp_in_vbi_months,


### PR DESCRIPTION
Computed Period Difference on Project Department history, Reporting Changes
Replaced End date with current date in Project Department history, Reporting Changes
When Employee Type Intern then replace Date of Join by Date of Start of Internship and Date of Exit by Date of End od Internshio